### PR TITLE
Fix races between pki and connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -186,8 +186,11 @@ func New(cfg *ClientConfig) (*Client, error) {
 	c.log.Debugf("User Link Key is: %v", c.cfg.LinkKey.PublicKey())
 
 	c.rng = rand.NewMath()
-	c.pki = newPKI(c)
+
 	c.conn = newConnection(c)
+	c.pki = newPKI(c)
+	c.pki.start()
+	c.conn.start()
 
 	return c, nil
 }

--- a/connection.go
+++ b/connection.go
@@ -761,6 +761,10 @@ func (c *connection) getConsensus(ctx context.Context, epoch uint64) (*commands.
 	// NOTREACHED
 }
 
+func (c *connection) start() {
+	c.Go(c.connectWorker)
+}
+
 func newConnection(c *Client) *connection {
 	k := new(connection)
 	k.c = c
@@ -769,7 +773,5 @@ func newConnection(c *Client) *connection {
 	k.fetchCh = make(chan interface{}, 1)
 	k.sendCh = make(chan *connSendCtx)
 	k.getConsensusCh = make(chan *getConsensusCtx)
-
-	k.Go(k.connectWorker)
 	return k
 }

--- a/pki.go
+++ b/pki.go
@@ -266,13 +266,15 @@ func (p *pki) pruneFailures(now uint64) {
 	}
 }
 
+func (p *pki) start() {
+	p.Go(p.worker)
+}
+
 func newPKI(c *Client) *pki {
 	p := new(pki)
 	p.c = c
 	p.log = c.cfg.LogBackend.GetLogger("minclient/pki:" + c.displayName)
 	p.failedFetches = make(map[uint64]error)
 	p.forceUpdateCh = make(chan interface{}, 1)
-
-	p.Go(p.worker)
 	return p
 }


### PR DESCRIPTION
I don't actually have a unit test that proves this change fixes the problem... however when building my ``noop`` client with the race detector it detects races without this patch to minclient.