### PR TITLE
Add warped epoch flag

### DIFF
--- a/pki.go
+++ b/pki.go
@@ -32,9 +32,10 @@ import (
 
 var (
 	errGetConsensusCanceled = errors.New("minclient/pki: consensus fetch canceled")
-	errConsensusNotFound = errors.New("minclient/pki: consensus not ready yet")
+	errConsensusNotFound    = errors.New("minclient/pki: consensus not ready yet")
 	nextFetchTill           = 7 * (epochtime.Period / 8)
 	recheckInterval         = 1 * time.Minute
+	// WarpedEpoch is a build time flag that accelerates the recheckInterval
 	WarpedEpoch             = "false"
 )
 

--- a/pki.go
+++ b/pki.go
@@ -30,7 +30,12 @@ import (
 	"gopkg.in/op/go-logging.v1"
 )
 
-var errGetConsensusCanceled = errors.New("minclient/pki: consensus fetch canceled")
+var (
+	errGetConsensusCanceled = errors.New("minclient/pki: consensus fetch canceled")
+	nextFetchTill           = 7 * (epochtime.Period / 8)
+	recheckInterval         = 1 * time.Minute
+	WarpedEpoch             = "false"
+)
 
 type pki struct {
 	sync.Mutex
@@ -116,10 +121,6 @@ func (p *pki) worker() {
 
 	var lastCallbackEpoch uint64
 	for {
-		const (
-			nextFetchTill   = 7*(epochtime.Period/8)
-			recheckInterval = 1 * time.Minute
-		)
 
 		timerFired := false
 		select {
@@ -277,4 +278,10 @@ func newPKI(c *Client) *pki {
 	p.failedFetches = make(map[uint64]error)
 	p.forceUpdateCh = make(chan interface{}, 1)
 	return p
+}
+
+func init() {
+	if WarpedEpoch == "true" {
+		recheckInterval = 20 * time.Second
+	}
 }

--- a/pki.go
+++ b/pki.go
@@ -33,7 +33,7 @@ import (
 var (
 	errGetConsensusCanceled = errors.New("minclient/pki: consensus fetch canceled")
 	errConsensusNotFound    = errors.New("minclient/pki: consensus not ready yet")
-	nextFetchTill           = 7 * (epochtime.Period / 8)
+	nextFetchTill           = 1 * (epochtime.Period / 8)
 	recheckInterval         = 1 * time.Minute
 	// WarpedEpoch is a build time flag that accelerates the recheckInterval
 	WarpedEpoch             = "false"

--- a/send.go
+++ b/send.go
@@ -92,8 +92,6 @@ func (c *Client) ComposeSphinxPacket(recipient, provider string, surbID *[sConst
 				if err != nil {
 					return nil, nil, 0, err
 				}
-
-				err = c.conn.sendPacket(pkt)
 				return pkt, k, then.Sub(now), err
 			} else {
 				pkt, err := sphinx.NewPacket(rand.Reader, fwdPath, payload)


### PR DESCRIPTION
Client tests need to check more frequently for a descriptor when epochtime.Period is shortened. This PR adds the build time flag WarpedEpoch to do so.