### PR TITLE
Fix bug where minclient aborts fetching consensus

### DIFF
--- a/pki.go
+++ b/pki.go
@@ -118,7 +118,7 @@ func (p *pki) worker() {
 	var lastCallbackEpoch uint64
 	for {
 		var (
-			nextFetchTill   = 7 * (epochtime.Period / 8)
+			nextFetchTill   = 1 * (epochtime.Period / 8)
 			recheckInterval = 1 * time.Minute
 		)
 

--- a/pki.go
+++ b/pki.go
@@ -164,8 +164,6 @@ func (p *pki) worker() {
 				switch err {
 				case cpki.ErrNoDocument:
 					p.failedFetches[epoch] = err
-				case errConsensusNotFound:
-					return
 				case errGetConsensusCanceled:
 					return
 				default:


### PR DESCRIPTION
If the consensus fetch is attempted before the consensus is available,
minclient gives up upon failure and does not retry.